### PR TITLE
Implement initial module and CLI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,1 +1,16 @@
-node_modules/@retailmenot/core-ui-editorconfig/.editorconfig
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[.eslintrc]
+indent_style = space
+
+[*.md]
+indent_style = space
+
+[*.{json,yml,yaml}]
+indent_style = space

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,5 @@
 # vim: set syntax=yaml:
 ---
   extends: "./node_modules/@retailmenot/core-ui-eslintrc/.eslintrc-es6"
+  rules:
+    indent: ["error", 2]

--- a/bin/proving-ground.js
+++ b/bin/proving-ground.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const provingGround = require('../');
+
+const argv = require('yargs')
+  .usage('Usage: $0 [options] [files or directories]')
+  .option('e', {
+    alias: 'exec',
+    default: 'node',
+    describe: 'the command to pass to prove as its `exec` parameter',
+    type: 'string'
+  })
+  .option('n', {
+    alias: 'num-processes',
+    default: 1,
+    describe: 'the level of parallelism `prove` should employ',
+    type: 'string'
+  })
+  .option('before', {
+    default: null,
+    describe: 'a module exporting a function to run before `prove`',
+    type: 'string'
+  })
+  .option('after', {
+    default: null,
+    describe: 'a module exporting a function to run after `prove`',
+    type: 'string'
+  })
+  .help('h')
+  .alias('h', 'help')
+  .version()
+  .argv;
+
+const config = {
+  exec: argv.exec,
+  numProcesses: argv.n,
+  files: argv._
+};
+
+if (argv.before !== null) {
+  config.before = require(path.resolve(argv.before));
+}
+
+if (argv.after !== null) {
+  config.after = require(path.resolve(argv.after));
+}
+
+provingGround.run(config)
+  .on('error', err => {
+    console.error(err.stack);
+    process.exit(1);
+  })
+  .on('start', child => {
+    child.stderr.pipe(process.stderr);
+    child.stdout.pipe(process.stdout);
+  })
+  .on('end', code => {
+    process.exit(code);
+  });

--- a/bin/proving-ground.js
+++ b/bin/proving-ground.js
@@ -31,6 +31,7 @@ const argv = require('yargs')
   .help('h')
   .alias('h', 'help')
   .version()
+  .epilogue('For details on prove(1), man or https://linux.die.net/man/1/prove')
   .argv;
 
 const config = {

--- a/bin/proving-ground.js
+++ b/bin/proving-ground.js
@@ -15,17 +15,17 @@ const argv = require('yargs')
   .option('n', {
     alias: 'num-processes',
     default: 1,
-    describe: 'the level of parallelism `prove` should employ',
+    describe: 'the level of parallelism prove should employ',
     type: 'string'
   })
   .option('before', {
     default: null,
-    describe: 'a module exporting a function to run before `prove`',
+    describe: 'a module exporting a function to run before prove',
     type: 'string'
   })
   .option('after', {
     default: null,
-    describe: 'a module exporting a function to run after `prove`',
+    describe: 'a module exporting a function to run after prove',
     type: 'string'
   })
   .help('h')

--- a/examples/leadfoot/after.js
+++ b/examples/leadfoot/after.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./selenium').teardown;

--- a/examples/leadfoot/before.js
+++ b/examples/leadfoot/before.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const setup = require('./selenium').setup;
+module.exports = setup.bind(null, 4);

--- a/examples/leadfoot/common.js
+++ b/examples/leadfoot/common.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Server = require('leadfoot/Server');
+
+module.exports = () => {
+  const server = new Server('http://localhost:4444/wd/hub');
+
+  return server.createSession({
+    browserName: 'chrome'
+  })
+  .catch((err) => {
+    console.error('DOH!', err.message);
+    console.error(err.stack);
+  });
+};

--- a/examples/leadfoot/package.json
+++ b/examples/leadfoot/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "proving-ground-examples-leadfoot",
+  "version": "1.0.0",
+  "description": "Example of using proving-ground to run leadfoot tests in parallel",
+  "scripts": {
+    "one": "../../bin/proving-ground.js --before ./before.js --after ./after.js ./test/*.js",
+    "two": "../../bin/proving-ground.js -n 2 --before ./before.js --after ./after.js ./test/*.js",
+    "four": "../../bin/proving-ground.js -n 4 --before ./before.js --after ./after.js ./test/*.js",
+    "prepublish": "exit 1"
+  },
+  "dependencies": {
+    "leadfoot": "^1.7.0",
+    "selenium-standalone": "^5.9.0",
+    "tap": "^8.0.1"
+  }
+}

--- a/examples/leadfoot/selenium.js
+++ b/examples/leadfoot/selenium.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const selenium = require('selenium-standalone');
+
+const URL = 'http://localhost:4444';
+const children = [];
+
+function setup(numNodes, done) {
+  console.log('Starting selenium grid with %d nodes...', numNodes);
+
+  function callback(err, child) {
+    if (err) {
+      console.error(err, err.stack);
+      teardown();
+      return;
+    }
+
+    children.push(child);
+
+    if (children.length >= numNodes + 1) {
+      console.log('...done');
+      done();
+    }
+  }
+
+  selenium.start({
+    seleniumArgs: ['-role', 'hub']
+  }, (err, child) => {
+    if (err) {
+      done(err);
+      return;
+    }
+
+    children.push(child);
+
+    for (let i = 0; i < numNodes; i++) {
+      selenium.start({
+        seleniumArgs: [
+          '-role', 'node',
+          URL + '/grid/register',
+          '-port', 5555 + i
+        ]
+      }, callback);
+    }
+  });
+}
+
+function teardown(done) {
+  console.log('Tearing down selenium grid...');
+  while (children.length > 0) {
+    children.pop().kill();
+  }
+
+  console.log('...done');
+  done();
+}
+
+module.exports = {
+  setup: setup,
+  teardown: teardown,
+  URL: URL
+};

--- a/examples/leadfoot/test/eight.js
+++ b/examples/leadfoot/test/eight.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/examples/leadfoot/test/five.js
+++ b/examples/leadfoot/test/five.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/examples/leadfoot/test/four.js
+++ b/examples/leadfoot/test/four.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/examples/leadfoot/test/one.js
+++ b/examples/leadfoot/test/one.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/examples/leadfoot/test/seven.js
+++ b/examples/leadfoot/test/seven.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/examples/leadfoot/test/six.js
+++ b/examples/leadfoot/test/six.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/examples/leadfoot/test/three.js
+++ b/examples/leadfoot/test/three.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/examples/leadfoot/test/two.js
+++ b/examples/leadfoot/test/two.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Command = require('leadfoot/Command');
+const tap = require('tap');
+const sessionPromise = require('../common')();
+
+tap.test(__filename, t => {
+  let session;
+
+  return sessionPromise
+    .then(s => {
+      session = s;
+      const command = new Command(session);
+
+      return command.get('https://google.com')
+        .getPageTitle()
+        .then(title => {
+          t.notEqual(title, '', 'non-empty title');
+
+          return new Promise(resolve => setTimeout(resolve, 1000));
+        })
+        .then(() => {
+          return session.server.deleteSession(session.sessionId);
+        });
+    });
+});

--- a/index.js
+++ b/index.js
@@ -1,5 +1,92 @@
 'use strict';
+const spawn = require('child_process').spawn;
+const EventEmitter = require('events');
+
+function callAsync(fn) {
+  return new Promise((resolve, reject) => {
+    const callback = (err, value) => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve(value);
+      }
+    };
+
+    let fnResult;
+    try {
+      fnResult = fn(callback);
+    } catch (err) {
+      reject(err);
+    }
+
+    if (
+      fnResult &&
+      typeof fnResult.then === 'function' &&
+      typeof fnResult.then === 'function'
+    ) {
+      fnResult.then(resolve).catch(reject);
+    }
+  });
+}
+
+function run(config) {
+  const emitter = new EventEmitter();
+
+  config = config || {};
+  config.exec = config.exec || "'node'";
+  config.files = config.files || [];
+  config.numProcesses = config.numProcesses || 1;
+
+  let beforePromise = Promise.resolve();
+
+  if (config.before) {
+    beforePromise = callAsync(config.before);
+  }
+
+  beforePromise
+    .then(() => {
+      let child = spawn(
+        'prove',
+        [
+          '--exec',
+          config.exec,
+          '--jobs',
+          config.numProcesses
+        ].concat(config.files)
+      );
+
+      const promise = new Promise((resolve, reject) => {
+        child.on('error', reject);
+
+        child.on('exit', (code, signal) => {
+          if (signal) {
+            reject(signal);
+          }
+
+          resolve(code);
+        });
+      });
+
+      emitter.emit('start', child);
+
+      return promise;
+    })
+    .then(code => {
+      let afterPromise = Promise.resolve();
+
+      if (config.after) {
+        afterPromise = callAsync(config.after);
+      }
+
+      return afterPromise.then(() => {
+        emitter.emit('end', code);
+      });
+    })
+    .catch(err => emitter.emit('error', err));
+
+  return emitter;
+}
 
 module.exports = {
-	run: () => {}
+  run: run
 };

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function callAsync(fn) {
     if (
       fnResult &&
       typeof fnResult.then === 'function' &&
-      typeof fnResult.then === 'function'
+      typeof fnResult.catch === 'function'
     ) {
       fnResult.then(resolve).catch(reject);
     }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Run JavaScript test files in parallel with the power of Perl's prove",
   "main": "index.js",
+  "bin": "bin/proving-ground.js",
   "scripts": {
     "lint": "eslint .",
     "test": "tap -Rspec test/*.js --cov"
@@ -29,8 +30,12 @@
     "@retailmenot/core-ui-eslintrc": "^5.0.0",
     "@retailmenot/core-ui-gitignore": "^1.0.1",
     "eslint": "^3.11.0",
+    "mockery": "^2.0.0",
+    "sinon": "^1.17.6",
     "tap": "^8.0.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "yargs": "^6.5.0"
+  },
   "keywords": []
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+ssh://git@github.com/RetailMeNotSandbox/proving-ground.git"
   },
   "engines": {
-    "node": "^4.6",
+    "node": "^4.6 || ^6.9",
     "npm": "^2.0"
   },
   "bugs": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,15 +1,441 @@
 'use strict';
 
-var tap = require('tap');
-
-var provingGround = require('../');
+const mockery = require('mockery');
+const sinon = require('sinon');
+const tap = require('tap');
+const EventEmitter = require('events');
 
 tap.test('API', function (t) {
-	t.autoend();
+  t.autoend();
 
-	t.type(
-		provingGround.run,
-		'function',
-		'exports a `run` method'
-	);
+  mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+  });
+
+  const mockSpawn = sinon.stub();
+
+  let expected;
+  function resetMockSpawn() {
+    expected = new EventEmitter();
+    expected.stderr = {};
+    expected.stdout = {};
+
+    mockSpawn.reset();
+    mockSpawn.returns(expected);
+  }
+
+  mockery.registerMock('child_process', {
+    spawn: mockSpawn
+  });
+
+  const provingGround = require('../');
+
+  t.tearDown(() => {
+    mockery.disable();
+  });
+
+  t.type(
+    provingGround.run,
+    'function',
+    'exports a `run` method'
+  );
+
+  t.test('`run`', t => {
+    t.autoend();
+
+    t.test('spawns `prove` as a child process', t => {
+      resetMockSpawn();
+
+      provingGround.run()
+        .on('start', () => {
+          t.ok(mockSpawn.calledOnce, 'calls `child_process.spawn`');
+          t.ok(
+            mockSpawn.firstCall.calledWith('prove'),
+            'passes `prove` as the command'
+          );
+
+          t.end();
+        });
+    });
+
+    t.test('emits an `error` if `prove` exits due to a signal', t => {
+      resetMockSpawn();
+
+      provingGround.run()
+        .on('error', err => {
+          t.equal(err, 'SIG_FEELS');
+
+          t.end();
+        })
+        .on('start', () => {
+          expected.emit('exit', null, 'SIG_FEELS');
+        });
+    });
+
+    t.test('return value', t => {
+      resetMockSpawn();
+
+      const result = provingGround.run();
+
+      t.type(result, 'EventEmitter', 'is an `EventEmitter`');
+
+      result.on('start', value => {
+        t.type(
+          value,
+          'EventEmitter',
+          'emitted value is an `EventEmitter`'
+        );
+        t.equal(
+          value.stderr,
+          expected.stderr,
+          'emitted value has a `stderr` property that is the child stderr'
+        );
+        t.equal(
+          value.stdout,
+          expected.stdout,
+          'emitted value has a `stdout` property that is the child stdout'
+        );
+
+        t.end();
+      });
+    });
+
+    t.test('accepts an optional `config` object', t => {
+      t.autoend();
+
+      t.test('`config.exec`', t => {
+        const expectedExec = "'node ./node_modules/.bin/mocha'";
+        resetMockSpawn();
+
+        provingGround.run()
+          .on('start', () => {
+            const args = mockSpawn.firstCall.args[1] || [];
+
+            t.ok(
+              args.join(' ').indexOf("--exec 'node'") >= 0,
+              'tells prove to run the tests with node by default'
+            );
+
+            resetMockSpawn();
+
+            provingGround.run({
+              exec: expectedExec
+            })
+            .on('start', () => {
+              const args = mockSpawn.firstCall.args[1] || [];
+
+              t.ok(
+                args.join(' ').indexOf('--exec ' + expectedExec) >= 0,
+                'if `config.exec` set, tells prove to use that command'
+              );
+
+              t.end();
+            });
+          });
+      });
+
+      t.test('`config.numProcesses`', t => {
+        const expectedNumProcesses = 42;
+        resetMockSpawn();
+
+        provingGround.run()
+          .on('start', () => {
+            const args = mockSpawn.firstCall.args[1] || [];
+
+            t.ok(
+              args.join(' ').indexOf('--jobs 1') >= 0,
+              'tells prove use 1 process by default'
+            );
+
+            resetMockSpawn();
+
+            provingGround.run({
+              numProcesses: expectedNumProcesses
+            })
+            .on('start', () => {
+              const args = mockSpawn.firstCall.args[1] || [];
+
+              t.ok(
+                args.join(' ').indexOf('--jobs ' + expectedNumProcesses) >= 0,
+                'if `config.numProcesses` is provided, tells prove to use ' +
+                  'that many processes'
+              );
+
+              t.end();
+            });
+          });
+      });
+
+      t.test('`config.files`', t => {
+        resetMockSpawn();
+
+        const expectedFiles = [
+          'test/foo/**/*.js',
+          'test/*.js'
+        ];
+
+        provingGround.run({
+          files: expectedFiles
+        })
+        .on('start', () => {
+          const args = mockSpawn.firstCall.args[1] || [];
+
+          t.same(
+            args.slice(-2),
+            expectedFiles,
+            '`config.files` elements should be passed as positional args'
+          );
+
+          t.end();
+        });
+      });
+
+      t.test('`config.before`', t => {
+        resetMockSpawn();
+
+        const beforeStub = sinon.stub();
+
+        provingGround.run({
+          before: beforeStub
+        });
+
+        t.ok(beforeStub.calledOnce, 'called once');
+        t.ok(!mockSpawn.called, 'called before `prove` spawned');
+        t.type(beforeStub.firstCall.args[0], 'function', 'passed a callback');
+
+        t.test('if `config.before` throws', t => {
+          const expectedErr = new Error();
+
+          resetMockSpawn();
+          beforeStub.reset();
+          beforeStub.throws(expectedErr);
+
+          provingGround.run({
+            before: beforeStub
+          })
+          .on('start', () => t.fail('start event should not be emitted'))
+          .on('error', err => {
+            t.equal(err, expectedErr, 'emits thrown error as `error` data');
+            t.ok(!mockSpawn.called, '`prove` not spawned');
+
+            t.end();
+          });
+        });
+
+        t.test('if `config.before` returns a promise', t => {
+          t.test('if promise resolves', t => {
+            resetMockSpawn();
+            beforeStub.reset();
+            beforeStub.returns(Promise.resolve());
+
+            provingGround.run({
+              before: beforeStub
+            })
+            .on('start', () => {
+              t.ok(mockSpawn.called, '`prove` spawned');
+
+              t.end();
+            });
+          });
+
+          t.test('if promise rejects', t => {
+            const expectedErr = new Error();
+
+            resetMockSpawn();
+            beforeStub.reset();
+            beforeStub.returns(Promise.reject(expectedErr));
+
+            provingGround.run({
+              before: beforeStub
+            })
+            .on('start', () => t.fail('start event should not be emitted'))
+            .on('error', err => {
+              t.equal(err, expectedErr, 'emits reason as `error` data');
+              t.ok(!mockSpawn.called, '`prove` not spawned');
+
+              t.end();
+            });
+          });
+
+          t.end();
+        });
+
+        t.test('if `config.before` invokes its callback', t => {
+          t.test('without an error', t => {
+            resetMockSpawn();
+            beforeStub.reset();
+            beforeStub.returns(undefined);
+            beforeStub.callsArgWith(0, null);
+
+            provingGround.run({
+              before: beforeStub
+            })
+            .on('start', () => {
+              t.ok(mockSpawn.called, '`prove` spawned');
+
+              t.end();
+            });
+          });
+
+          t.test('with an error', t => {
+            const expectedErr = new Error('ugh');
+
+            resetMockSpawn();
+            beforeStub.reset();
+            beforeStub.returns(undefined);
+            beforeStub.callsArgWith(0, expectedErr);
+
+            provingGround.run({
+              before: beforeStub
+            })
+            .on('start', () => t.fail('start event should not be emitted'))
+            .on('error', err => {
+              t.equal(err, expectedErr, 'emits passed error as `error` data');
+              t.ok(!mockSpawn.called, '`prove` not spawned');
+
+              t.end();
+            });
+          });
+
+          t.end();
+        });
+
+        t.end();
+      });
+
+      t.test('`config.after`', t => {
+        resetMockSpawn();
+
+        const afterStub = sinon.stub().returns(Promise.resolve());
+
+        t.test('called after `prove` runs', t => {
+          provingGround.run({
+            after: afterStub
+          })
+          .on('start', child => {
+            expected.emit('exit', 0, null);
+          })
+          .on('error', err => t.fail(err))
+          .on('end', () => {
+            t.ok(afterStub.calledOnce, 'called once');
+            t.ok(mockSpawn.called, 'called after `prove` spawned');
+            t.type(
+              afterStub.firstCall.args[0],
+              'function',
+              'passed a callback'
+            );
+
+            t.end();
+          });
+        });
+
+        t.test('if `config.after` throws', t => {
+          const expectedErr = new Error();
+
+          afterStub.reset();
+          afterStub.throws(expectedErr);
+
+          provingGround.run({
+            after: afterStub
+          })
+          .on('start', child => {
+            expected.emit('exit', 0, null);
+          })
+          .on('end', () => t.fail('end event should not be emitted'))
+          .on('error', err => {
+            t.equal(err, expectedErr, 'emits thrown error as `error` data');
+
+            t.end();
+          });
+        });
+
+        t.test('if `config.after` returns a promise', t => {
+          t.test('if promise resolves', t => {
+            afterStub.reset();
+            afterStub.returns(Promise.resolve());
+
+            provingGround.run({
+              after: afterStub
+            })
+            .on('start', child => {
+              expected.emit('exit', 0, null);
+            })
+            .on('end', () => {
+              t.pass('`end` emitted');
+
+              t.end();
+            });
+          });
+
+          t.test('if promise rejects', t => {
+            const expectedErr = new Error();
+
+            afterStub.reset();
+            afterStub.returns(Promise.reject(expectedErr));
+
+            provingGround.run({
+              after: afterStub
+            })
+            .on('start', child => {
+              expected.emit('exit', 0, null);
+            })
+            .on('end', () => t.fail('end event should not be emitted'))
+            .on('error', err => {
+              t.equal(err, expectedErr, 'emits reason as `error` data');
+
+              t.end();
+            });
+          });
+
+          t.end();
+        });
+
+        t.test('if `config.after` invokes its callback', t => {
+          t.test('without an error', t => {
+            afterStub.reset();
+            afterStub.returns(undefined);
+            afterStub.callsArgWith(0, null);
+
+            provingGround.run({
+              after: afterStub
+            })
+            .on('start', child => {
+              expected.emit('exit', 0, null);
+            })
+            .on('end', () => {
+              t.pass('`end` emitted');
+
+              t.end();
+            });
+          });
+
+          t.test('with an error', t => {
+            const expectedErr = new Error('ugh');
+
+            afterStub.reset();
+            afterStub.returns(undefined);
+            afterStub.callsArgWith(0, expectedErr);
+
+            provingGround.run({
+              after: afterStub
+            })
+            .on('start', child => {
+              expected.emit('exit', 0, null);
+            })
+            .on('end', () => t.fail('end event should not be emitted'))
+            .on('error', err => {
+              t.equal(err, expectedErr, 'emits passed error as `error` data');
+
+              t.end();
+            });
+          });
+
+          t.end();
+        });
+
+        t.end();
+      });
+    });
+  });
 });


### PR DESCRIPTION
The `run` method runs tests with `prove`. It takes a config object and returns
an `EventEmitter`. Currently, it is possible to configure the level of
concurrency and the command to run tests with. It's also possible to specify JS
modules to run before and after the tests.

The CLI wraps `run` and is installed as `proving-ground`.

An example (runnable via the CLI) can be found in examples/leadfoot/.

---

Remaining work:
- [x] ~~README~~
- [x] ~~examples/leadfoot/README~~
- [x] ~~JSDoc~~
- [x] ~~CONTRIBUTING~~

I'll tackle this in #2.

---

To run the demo:

```
npm install
cd examples/leadfoot
npm install
../../bin/proving-ground.js -n 4 --before ./before.js --after ./after.js test/*.js
```

This will run the demo with 4 concurrent tests.